### PR TITLE
Files changed

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -30,6 +30,9 @@ jobs:
   MSDO:
     # currently only windows latest is supported
     runs-on: windows-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mr-adonisjimenez/mr-adonisjimenez.github.io/security/code-scanning/1](https://github.com/mr-adonisjimenez/mr-adonisjimenez.github.io/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
1. The `actions/checkout` action typically requires `contents: read` permission to access the repository's files.
2. The `microsoft/security-devops-action` and `github/codeql-action/upload-sarif` actions may require additional permissions, such as `security-events: write` for uploading SARIF files to the Security tab.

The `permissions` block should be added at the workflow level (to apply to all jobs) or at the job level (specific to the `MSDO` job). For this workflow, adding it at the job level is more precise.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
